### PR TITLE
Fixed opening Library files in Level 2 on windows

### DIFF
--- a/src/org/rascalmpl/eclipse/editor/ParseController.java
+++ b/src/org/rascalmpl/eclipse/editor/ParseController.java
@@ -123,7 +123,7 @@ public class ParseController implements IParseController, IMessageHandlerProvide
 			location = ProjectURIResolver.constructProjectURI(project, path);
 			this.parser = ProjectEvaluatorFactory.getInstance().createProjectEvaluator(project.getRawProject());
 		} else {
-			location = FileURIResolver.constructFileURI(path.toOSString());
+			location = FileURIResolver.constructFileURI(path.toString());
 			this.parser = ProjectEvaluatorFactory.getInstance().getEvaluator(null);
 		}
 


### PR DESCRIPTION
Fixes issue #302.

I recommend reviewing all usages of toOSString when creating URIs, because even on windows all slashes in URIs are forward slashes and not the OS separator.
