### PR TITLE
Missing return statement, for project:// URIs

### DIFF
--- a/src/org/rascalmpl/eclipse/console/internal/RascalHyperlink.java
+++ b/src/org/rascalmpl/eclipse/console/internal/RascalHyperlink.java
@@ -114,6 +114,7 @@ public class RascalHyperlink implements IHyperlink {
 		          if (getOffsetPart() > -1 && part instanceof ITextEditor) {
 		            ((ITextEditor)part).selectAndReveal(getOffsetPart(), getLength());
 		          }
+		          return;
 		        }
 
 		        if (resourceURI != null) {


### PR DESCRIPTION
Fixes opening rascal:// locs in stacktraces in the console at least on Windows.
